### PR TITLE
Swap round conditional expression

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ resource "aws_iam_role_policy_attachment" "main" {
 
 resource "aws_eks_fargate_profile" "main" {
   cluster_name           = var.cluster_name
-  fargate_profile_name   = var.fargate_profile_name == null ? var.fargate_profile_name : format("fargate-profile-%s", var.namespace)
+  fargate_profile_name   = var.fargate_profile_name != null ? var.fargate_profile_name : format("fargate-profile-%s", var.namespace)
   pod_execution_role_arn = aws_iam_role.main.arn
   subnet_ids             = var.subnet_ids
   tags                   = local.tags


### PR DESCRIPTION
The module currently errors if `fargate_profile_name` is not set.

```
Error: Missing required argument

  with module.eks-fargate-profile.aws_eks_fargate_profile.main,
  on .terraform/modules/eks-fargate-profile/main.tf line 40, in resource "aws_eks_fargate_profile" "main":
  40:   fargate_profile_name   = var.fargate_profile_name == null ? var.fargate_profile_name : format("fargate-profile-%s", var.namespace)

The argument "fargate_profile_name" is required, but no definition was found.
```